### PR TITLE
Adding Post Setup Handlers to Start Up

### DIFF
--- a/lib/gamebox/post_setup_handlers/file_watcher.rb
+++ b/lib/gamebox/post_setup_handlers/file_watcher.rb
@@ -1,0 +1,39 @@
+module PostSetupHandlers
+
+  class FileWatcher
+
+    def self.setup(argv,env,config)
+      start_file_watcher if config[:debug] or argv.include?('--debug')
+    end
+
+    def self.filepaths
+      [ "src/behaviors/", "src/actors" ]
+    end
+
+    def self.start_file_watcher
+      log "File Watcher is now watching (#{filepaths.join(', ')}) for changes."
+
+      Thread.abort_on_exception = true
+
+      Thread.new do
+        require 'listen'
+        Listen.to(*filepaths, filter: /\.rb$/) do |modified, added, removed|
+          (modified + added).each do |path|
+            path[/([^\/]*)\.rb/]
+            filename = $1
+            case path
+            when /behaviors/
+              reload_behavior filename
+            when /actors/
+              load_actor filename
+            end
+          end
+        end
+      end
+    end
+
+  end
+
+  GameboxApp.register_post_setup_handler FileWatcher
+
+end

--- a/lib/gamebox/post_setup_handlers/gamebox_debug_helpers.rb
+++ b/lib/gamebox/post_setup_handlers/gamebox_debug_helpers.rb
@@ -1,0 +1,15 @@
+
+module PostSetupHandlers
+
+  class GameboxAppAddDebugHelpers
+    def self.setup(argv,env,config)
+      if config[:debug] or ARGV.include?("--debug")
+        log "GameboxApp now includes DEBUG Helpers"
+        GameboxApp.send :include, DebugHelpers
+      end
+    end
+
+  end
+
+  GameboxApp.register_post_setup_handler GameboxAppAddDebugHelpers
+end

--- a/lib/gamebox/post_setup_handlers/pry_remote_server.rb
+++ b/lib/gamebox/post_setup_handlers/pry_remote_server.rb
@@ -1,0 +1,31 @@
+module PostSetupHandlers
+  class PryRemoteServer
+    def self.setup(argv,env,config)
+      start_remote_pry if config[:debug] or argv.include?('--debug')
+    end
+
+    def self.start_remote_pry
+      log "Pry Remote Server started!"
+
+      Thread.abort_on_exception = true
+
+      Thread.new do
+        loop do
+          begin
+            if th = DRb.thread
+              th.kill
+            end
+
+            binding.remote_pry
+            log "remote_pry returned"
+          rescue Exception => e
+            log "finished remote pry"
+          end
+        end
+      end
+
+    end
+  end
+
+  GameboxApp.register_post_setup_handler PryRemoteServer
+end


### PR DESCRIPTION
Looking at start up I noticed that there were several things that were happening that were outside of the scope of the GameboxApp class and better suited to be executed individually.

This is a more modular approach to the **Post Setup Handlers** that were being executed by having them in separate classes and individually registering. This creates an interface that could allow other game developers to execute code.

Right now I simply have all the _argv_, _env_ and _config_ being passed to each one of the setup handlers because I do not yet possess the understanding of how I would go about merging those parameters.
