### PR TITLE
Require less to avoid requiring things from a vendored bundle.

### DIFF
--- a/templates/app/config/environment.rb
+++ b/templates/app/config/environment.rb
@@ -25,7 +25,7 @@ end
 [GAMEBOX_PATH, APP_ROOT, File.join(APP_ROOT,'src')].each{|path| $: << path }
 require "gamebox_application"
 
-require_all Dir.glob("**/*.rb").reject{ |f| f.match("spec") || f.match("src/app.rb")}
+require_all Dir.glob("{src,lib}/**/*.rb").reject{ |f| f.match("src/app.rb")}
 
 
 


### PR DESCRIPTION
Same as shawn42/killbox#14, but also include `lib/` because some examples make use of it.

No new tests, but existing tests pass.
