### PR TITLE
fix `rake bundle` task

### DIFF
--- a/lib/gamebox/tasks/gamebox_tasks.rake
+++ b/lib/gamebox/tasks/gamebox_tasks.rake
@@ -22,7 +22,12 @@ end
 desc "Bundle in all required gems"
 task :bundle do |t|
   sh "bundle package"
-  sh "bundle install vendor/bundle --disable-shared-gems"
+
+  if Bundler::VERSION =~ /^0/
+    sh "bundle install vendor/bundle --disable-shared-gems"
+  else
+    sh "bundle install --deployment"
+  end
 end
 
 desc "Run specs"


### PR DESCRIPTION
Bundler has had `bundle install --deployment` since 1.0

This checks whether Bundler version starts with a 0 and if not, runs the
new command
