### PR TITLE
Update to vector2.rb

### DIFF
--- a/lib/gamebox/lib/vector2.rb
+++ b/lib/gamebox/lib/vector2.rb
@@ -25,6 +25,7 @@
 # 
 class Vector2
   include Enumerable
+  include MinMaxHelpers
 
   RAD_TO_DEG = 180.0 / Math::PI
   DEG_TO_RAD = Math::PI / 180.0

--- a/lib/gamebox/lib/vector2.rb
+++ b/lib/gamebox/lib/vector2.rb
@@ -25,7 +25,6 @@
 # 
 class Vector2
   include Enumerable
-  include MinMaxHelpers
 
   RAD_TO_DEG = 180.0 / Math::PI
   DEG_TO_RAD = Math::PI / 180.0
@@ -197,7 +196,7 @@ class Vector2
   # 
   def ==( vector )
     return false if vector.nil?
-    _nearly_equal?(@x, vector.at(0)) and _nearly_equal?(@y, vector.at(1))
+    Vector2.vector_nearly_equal?(@x, vector.at(0)) and Vector2.vector_nearly_equal?(@y, vector.at(1))
   end
 
 
@@ -445,9 +444,10 @@ class Vector2
     vector
   end
 
-  # Check whether vectors are same according to toleranceRate
-  def self.vector_nearly_same?(first_vector,second_vector,toleranceRate)
-    return (magnitude_nearly_equal? and angle_nearly_equal?)
+  # Check whether vectors are same according to toleranceRate.By default tolerances are set to 10 ** -10 = 0.0000000001
+  def self.vector_nearly_equal?(first_vector,second_vector,toleranceRateForMagnitude = 1E-10,toleranceRateForAngle = 1E-10)
+    return (magnitude_nearly_equal?(first_vector,second_vector,toleranceRateForMagnitude) and
+            angle_nearly_equal?(first_vector,second_vector,toleranceRateForAngle))
   end
 
   # Check whether vectors' magnitude are same according to toleranceRate
@@ -457,7 +457,7 @@ class Vector2
 
   # Check whether vectors' angle are same according to toleranceRate
   def self.angle_nearly_equal?(first_vector,second_vector,toleranceRate)
-    return (first_vector-second_vector).angle <= toleranceRate
+    return (first_vector-second_vector).angle.abs <= toleranceRate
   end
 
   # Returns distance between 2 vectors


### PR DESCRIPTION
Bug has been found and fixed after few unit tests which is related to == operation. I also have observed MinMaxHelpers are obsolute in latest ruby versions and didn't remove it yet. I have also learnt usage of hash function and tested to work it out but it apparently doesn't really work so i suggest it to delete @hash variable and hash function for usability. Here is where i have seen from https://ruby-doc.org/core-2.5.3/Hash.html
"A user-defined class may be used as a hash key if the hash and eql? methods are overridden to provide meaningful behavior. By default, separate instances refer to separate hash keys."